### PR TITLE
Serve static resources via GitHub

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -36,6 +36,9 @@ const prefix_mapping = new Map([
   ['/presentations/', handlePresentationsRequest],
   ['/learn', handleLearnRequest],
   ['/benchmark', handleGitHubRequest],
+  ['/js', handleGitHubRequest],
+  ['/css', handleGitHubRequest],
+  ['/fonts', handleGitHubRequest],
 ]);
 
 export async function handleRequest(request: Request): Promise<Response> {


### PR DESCRIPTION
This change adds prefix mapping for the paths `/css`, `/js`, `/fonts` to be served by the GitHub handler instead of Pantheon.