### PR TITLE
Disable cache header on pantheon request

### DIFF
--- a/src/pantheon.ts
+++ b/src/pantheon.ts
@@ -18,8 +18,7 @@ export async function handlePantheonRequest(request: Request, production: boolea
 
   const cf = {
     cf: {
-      cacheEverything: true,
-      cacheTtl: 60 * 30, // a half hour
+      cacheEverything: false,
     },
   };
   let response = await fetch(changeUrl(request, url), cf);


### PR DESCRIPTION
Disables cache headers for the WordPress portions of the site. Currently, the cache headers are affecting the admin when logged in.