### PR TITLE
Add absolute redirect support to docs handler

### DIFF
--- a/src/docs.ts
+++ b/src/docs.ts
@@ -81,9 +81,17 @@ export async function handleDocsRequest(request: Request): Promise<Response> {
     let redirect_prefix = '<!--[if IE 6]> Redirect: ';
     if (text.startsWith(redirect_prefix)) {
       let target = new URL(request.url);
-      target.pathname = text
-        .substring(redirect_prefix.length)
-        .split(' <![endif]-->', 1)[0];
+      let path = text
+          .substring(redirect_prefix.length)
+          .split(' <![endif]-->', 1)[0];
+      let absolute_prefix = `https://${config.domain}`;
+
+      if (path.startsWith(absolute_prefix)) {
+        path = path.substring(absolute_prefix.length, path.length)
+      }
+
+      target.pathname = path;
+
       return Response.redirect(target.toString(), 301);
     } else {
       let rating_count = 1;


### PR DESCRIPTION
The current response text from docs for an absolute redirect starts with:

```
<!--[if IE 6]> Redirect: https://clickhouse.com/cloud/ <![endif]-->
```

This results in an attempted redirect using the URL as the path, i.e. https://clickhouse.com/https:/clickhouse.com/cloud/

I've updated the docs handler to support redirecting with absolute URL destinations by removing the domain when present, redirecting to only the provided path. This provides the following redirect locally while using wrangler:

http://127.0.0.1:8787/docs/en/commercial/cloud/
=> http://127.0.0.1:8787/cloud/

The expected redirect destination behavior, while still preserving the existing path based redirect behavior:

http://127.0.0.1:8787/docs/en/changelog/2017/
=> http://127.0.0.1:8787/docs/en/whats-new/changelog/2017/

I believe this should resolve the issue we're facing with the current redirect. Please let me know if there are any questions or revisions.

Thanks!