### PR TITLE
Fixed the CSP issue on https://clickhouse.com:

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -27,7 +27,19 @@ export function addDefaultHeaders(response: Response, delete_headers: string[] =
   response.headers.set('referrer-policy', 'no-referrer-when-downgrade');
   response.headers.set(
     'content-security-policy',
-    `default-src 'none'; script-src 'self' 'unsafe-eval' 'unsafe-inline' cdn.segment.com cdn.ampproject.org ajax.cloudflare.com static.cloudflareinsights.com boards.greenhouse.io *.algolia.net *.algolianet.com buttons.github.io mc.yandex.ru mc.yandex.com yastatic.net www.googletagmanager.com bam.nr-data.net js-agent.newrelic.com discover.clickhouse.com munchkin.marketo.net; style-src 'self' 'unsafe-inline' fonts.googleapis.com discover.clickhouse.com; img-src 'self' www.googletagmanager.com blog-images.clickhouse.com data: mc.yandex.ru mc.yandex.com secure.gravatar.com s.w.org; object-src 'self' blog-images.clickhouse.com; connect-src 'self' https://api.segment.io/v1/ https://api.segment.io/ https://cdn.segment.com/v1/projects/dZuEnmCPmWqDuSEzCvLUSBBRt8Xrh2el/settings https://cdn.segment.com/v1/projects/pYKX60InlEzX6aI1NeyVhSF3pAIRj4Xo/settings https://cdn.segment.com/analytics-next/bundles/* https://cdn.segment.com/next-integrations/integrations/* http://clickhouse.com www.google-analytics.com mc.yandex.ru mc.yandex.com api.github.com cdn.ampproject.org *.algolia.net *.algolianet.com *.ingest.sentry.io hn.algolia.com www.reddit.com bam.nr-data.net *.mktoresp.com yoast.com; child-src blob: mc.yandex.ru mc.yandex.com; frame-src blob: mc.yandex.ru mc.yandex.com www.youtube.com datalens.yandex blog-images.clickhouse.com boards.greenhouse.io discover.clickhouse.com; font-src 'self' fonts.gstatic.com data:; base-uri 'none'; form-action 'self' webto.salesforce.com; frame-ancestors webvisor.com metrika.yandex.ru metrica.yandex.com; prefetch-src 'self'`,
+    "default-src 'none';" +
+    "script-src 'self' 'unsafe-eval' 'unsafe-inline' cdn.segment.com cdn.ampproject.org ajax.cloudflare.com static.cloudflareinsights.com boards.greenhouse.io *.algolia.net *.algolianet.com buttons.github.io mc.yandex.ru mc.yandex.com yastatic.net www.googletagmanager.com www.googleadservices.com bam.nr-data.net js-agent.newrelic.com discover.clickhouse.com munchkin.marketo.net;" +
+    "style-src 'self' 'unsafe-inline' fonts.googleapis.com discover.clickhouse.com;" +
+    "img-src 'self' www.googletagmanager.com blog-images.clickhouse.com data: mc.yandex.ru mc.yandex.com secure.gravatar.com s.w.org;" +
+    "object-src 'self' blog-images.clickhouse.com;" +
+    "connect-src 'self' https://api.segment.io/v1/ https://api.segment.io/ https://cdn.segment.com/v1/projects/dZuEnmCPmWqDuSEzCvLUSBBRt8Xrh2el/settings https://cdn.segment.com/v1/projects/pYKX60InlEzX6aI1NeyVhSF3pAIRj4Xo/settings https://cdn.segment.com/analytics-next/bundles/* https://cdn.segment.com/next-integrations/integrations/* http://clickhouse.com www.google-analytics.com mc.yandex.ru mc.yandex.com api.github.com cdn.ampproject.org *.algolia.net *.algolianet.com *.ingest.sentry.io hn.algolia.com www.reddit.com bam.nr-data.net *.mktoresp.com yoast.com;" +
+    "child-src blob: mc.yandex.ru mc.yandex.com;" +
+    "frame-src blob: mc.yandex.ru mc.yandex.com www.youtube.com datalens.yandex blog-images.clickhouse.com boards.greenhouse.io discover.clickhouse.com;" +
+    "font-src 'self' fonts.gstatic.com data:;" +
+    "base-uri 'none';" +
+    "form-action 'self' webto.salesforce.com;" +
+    "frame-ancestors webvisor.com metrika.yandex.ru metrica.yandex.com;" +
+    "prefetch-src 'self'',"
   );
   const location = response.headers.get('location');
   for (let key of Object.keys(config.redirects)) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -39,7 +39,7 @@ export function addDefaultHeaders(response: Response, delete_headers: string[] =
     "base-uri 'none';" +
     "form-action 'self' webto.salesforce.com;" +
     "frame-ancestors webvisor.com metrika.yandex.ru metrica.yandex.com;" +
-    "prefetch-src 'self'',"
+    "prefetch-src 'self'"
   );
   const location = response.headers.get('location');
   for (let key of Object.keys(config.redirects)) {


### PR DESCRIPTION
Fixed the following issue on https://clickhouse.com: 

```(index):6 Refused to load the script 'https://www.googleadservices.com/pagead/conversion_async.js' because it violates the following Content Security Policy directive: "script-src 'self' 'unsafe-eval' 'unsafe-inline' cdn.segment.com cdn.ampproject.org ajax.cloudflare.com static.cloudflareinsights.com boards.greenhouse.io *.algolia.net *.algolianet.com buttons.github.io mc.yandex.ru mc.yandex.com yastatic.net www.googletagmanager.com bam.nr-data.net js-agent.newrelic.com discover.clickhouse.com munchkin.marketo.net". Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback.```