### PR TITLE
Redirect traffic from repo to packages subdomain

### DIFF
--- a/src/repo.ts
+++ b/src/repo.ts
@@ -13,6 +13,8 @@ export async function handleRepoRequest(request: Request) {
       },
     };
     return fetch(changeUrl(request, url), cf);
+  } else if (path.endsWith('/')) {
+    return Response.redirect('https://packages.clickhouse.com/', 302);
   } else {
     return fetch(changeUrl(request, url));
   }


### PR DESCRIPTION
It will start the process of switching to packages.clickhouse.com completely.

Fixes https://github.com/ClickHouse/ClickHouse/issues/41289