### PR TITLE
Remove a wrong notFound in the middle

### DIFF
--- a/src/packages.ts
+++ b/src/packages.ts
@@ -96,9 +96,6 @@ export async function handlePackagesRequest(request: Request): Promise<Response>
       obj = await bucket.head(key);
       if (obj) {
         return permanentRedirect({ location: pathname + '/' });
-      } else {
-        // The object is not found at all
-        return notFound();
       }
     }
   }


### PR DESCRIPTION
It prevented the redirects `/deb -> /deb/`

The 404 is fixed with the very last line `return notFound -> return notFound()`