### PR TITLE
updating learn proxy path

### DIFF
--- a/src/learn.ts
+++ b/src/learn.ts
@@ -25,7 +25,6 @@ export async function handleLearnRequest(request: Request) {
 
   } else {
     url.hostname = 'clickhouselearn.github.io';
-    url.pathname = url.pathname.replace('learn', 'home');
     proxy = await fetch(url.toString());
   }
 


### PR DESCRIPTION
this PR will update the proxy pathname of the `learn` worker to be able to proxy to the github pages root path