### PR TITLE
Change staging website url

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -9,7 +9,7 @@ export default {
 
     /// The content of this part of our new website.
     website: 'production-marketing-website.vercel.app',
-    website_staging: 'staging-marketing-website-clickhouse.vercel.app',
+    website_staging: 'marketing-website-git-main-clickhouse.vercel.app',
     website_staging2: 'dlico9114pefj.cloudfront.net',
   },
 


### PR DESCRIPTION
This will change the URL to the production marketing website project in vercel which would provide the preview mode in order to avoid deployment after making changes to strapi for verification purposes