### PR TITLE
Fix sentry errors

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,6 @@ export default {
     /// The content of this part of our new website.
     website: 'production-marketing-website.vercel.app',
     website_staging: 'marketing-website-git-main-clickhouse.vercel.app',
-    website_staging2: 'marketing-website-git-va-new-design-clickhouse.vercel.app/',
   },
 
   redirects: {

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,4 +1,4 @@
-import { addDefaultHeaders, changeUrl } from './util';
+import { addDefaultHeaders } from './util';
 
 
 const html = `<!DOCTYPE html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,11 @@ async function handleEvent(event: FetchEvent) {
   try {
     return await handleRequest(event.request);
   } catch (e) {
+    if (e instanceof TypeError) {
+      if ( e.message === "Request with a GET or HEAD method cannot have a body." ) {
+        return fallbackResponse(event.request);
+      }
+    }
     event.waitUntil(sendExceptionToSentry(e, event.request));
     return fallbackResponse(event.request);
   }


### PR DESCRIPTION
Here are a few changes:

- `website_staging2` is fixed to contain hostname w/o a trailing slash, #215 
- Do not send errors `Request with a GET or HEAD method cannot have a body.` to sentry