### PR TITLE
Remove Insecure 'unsafe-eval' from header response.

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -28,8 +28,8 @@ export function addDefaultHeaders(response: Response, delete_headers: string[] =
   response.headers.set(
     'content-security-policy',
     "default-src 'self';" +
-    "script-src 'self' 'unsafe-inline' cdnjs.cloudflare.com cdn.segment.com cdn.ampproject.org ajax.cloudflare.com static.cloudflareinsights.com boards.greenhouse.io *.algolia.net *.algolianet.com buttons.github.io yastatic.net www.googletagmanager.com www.googleadservices.com googleads.g.doubleclick.net bam.nr-data.net js-agent.newrelic.com discover.clickhouse.com munchkin.marketo.net player.vimeo.com connect.facebook.net cookie-cdn.cookiepro.com www.youtube.com;" +
-    "style-src 'self' 'unsafe-inline' cdnjs.cloudflare.com fonts.googleapis.com discover.clickhouse.com;" +
+    "script-src 'self' 'unsafe-eval' cdnjs.cloudflare.com cdn.segment.com cdn.ampproject.org ajax.cloudflare.com static.cloudflareinsights.com boards.greenhouse.io *.algolia.net *.algolianet.com buttons.github.io yastatic.net www.googletagmanager.com www.googleadservices.com googleads.g.doubleclick.net bam.nr-data.net js-agent.newrelic.com discover.clickhouse.com munchkin.marketo.net player.vimeo.com connect.facebook.net cookie-cdn.cookiepro.com www.youtube.com;" +
+    "style-src 'self' cdnjs.cloudflare.com fonts.googleapis.com discover.clickhouse.com;" +
     "img-src * 'self' data: https:;" +
     "object-src 'self' blog-images.clickhouse.com;" +
     "connect-src 'self' https://boards-api.greenhouse.io/ https://apim.workato.com/ https://api.segment.io/v1/ https://api.segment.io/ https://cdn.segment.com/v1/projects/dZuEnmCPmWqDuSEzCvLUSBBRt8Xrh2el/settings https://cdn.segment.com/v1/projects/pYKX60InlEzX6aI1NeyVhSF3pAIRj4Xo/settings https://cdn.segment.com/analytics-next/bundles/* https://cdn.segment.com/next-integrations/integrations/* http://clickhouse.com *.google-analytics.com api.github.com cdn.ampproject.org *.algolia.net *.algolianet.com *.ingest.sentry.io hn.algolia.com www.reddit.com bam.nr-data.net *.mktoresp.com yoast.com cdn.segment.com api.vimeo.com cookie-cdn.cookiepro.com geolocation.onetrust.com privacyportal.cookiepro.com *.clickhouse.com https://cdn.plyr.io https://noembed.com;" +

--- a/src/util.ts
+++ b/src/util.ts
@@ -28,7 +28,7 @@ export function addDefaultHeaders(response: Response, delete_headers: string[] =
   response.headers.set(
     'content-security-policy',
     "default-src 'self';" +
-    "script-src 'self' 'unsafe-eval' 'unsafe-inline' cdnjs.cloudflare.com cdn.segment.com cdn.ampproject.org ajax.cloudflare.com static.cloudflareinsights.com boards.greenhouse.io *.algolia.net *.algolianet.com buttons.github.io yastatic.net www.googletagmanager.com www.googleadservices.com googleads.g.doubleclick.net bam.nr-data.net js-agent.newrelic.com discover.clickhouse.com munchkin.marketo.net player.vimeo.com connect.facebook.net cookie-cdn.cookiepro.com www.youtube.com;" +
+    "script-src 'self' 'unsafe-inline' cdnjs.cloudflare.com cdn.segment.com cdn.ampproject.org ajax.cloudflare.com static.cloudflareinsights.com boards.greenhouse.io *.algolia.net *.algolianet.com buttons.github.io yastatic.net www.googletagmanager.com www.googleadservices.com googleads.g.doubleclick.net bam.nr-data.net js-agent.newrelic.com discover.clickhouse.com munchkin.marketo.net player.vimeo.com connect.facebook.net cookie-cdn.cookiepro.com www.youtube.com;" +
     "style-src 'self' 'unsafe-inline' cdnjs.cloudflare.com fonts.googleapis.com discover.clickhouse.com;" +
     "img-src * 'self' data: https:;" +
     "object-src 'self' blog-images.clickhouse.com;" +
@@ -46,8 +46,8 @@ export function addDefaultHeaders(response: Response, delete_headers: string[] =
 
     if (location && location.indexOf(origin) >= 0) {
       response.headers.set(
-          'location',
-          location.replace(origin, destination),
+        'location',
+        location.replace(origin, destination),
       );
     }
   }


### PR DESCRIPTION
We seem to have 'unsafe-eval' in our CSP policy on clickhouse.com, this flags potential connections and generates errors and is a security issue as it negates the primary CSP protection against XSS. 

[This](https://csper.io/evaluations/64db98a685fc03c44f1c0a74) is the current CSP and associated issues on our [clickhouse.com](http://clickhouse.com/). 
