### PR TITLE
Update handler.ts

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -68,7 +68,10 @@ export async function handleRequest(request: Request): Promise<Response> {
     request.headers.get('user-agent') ||
     '';
 
-  if (url.pathname === '/' && user_agent.startsWith('curl/')) {
+  if (
+    (url.pathname === '/' && user_agent.startsWith('curl/')) || 
+    (url.pathname === '/install.sh')
+  ) {
     return handleInstallScriptRequest(request);
   }
 


### PR DESCRIPTION
Adding handler for install.sh script - Some security conscious users may want to review the install script first inside browser so just handling `curl https://clickhouse.com` with user-agent is not enough. We will keep the previous behaviour for backward compatibility but we can start advocating the use of `curl https://clickhouse.com/install.sh | sh` more often to give people confident in downloading our script.

Discussion in HN: https://news.ycombinator.com/item?id=38502494